### PR TITLE
deploy to the AUR

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,0 +1,18 @@
+pkgbase = kdeplasma-arch-update-notifier-git
+	pkgdesc = KDE plasmoid that lets you know when arch updates are required. Takes all repo's into account (core, extra, aur, ...).
+	pkgver = 4.2.1
+	pkgrel = 1
+	url = https://github.com/bouteillerAlan/archupdate
+	arch = any
+	license = GPL3
+	makedepends = git
+	depends = konsole
+	depends = pacman-contrib
+	depends = yay
+	depends = kdialog
+	optdepends = paru: paru support
+	source = git+https://github.com/bouteillerAlan/archupdate.git#tag=ddaf9d2d3e0b75c4ba3c39d1060cbc30190990b7?signed
+	validpgpkeys = 6A2ECC8A396F8A943A109A1E0F11C2A6BF79111E
+	sha256sums = SKIP
+
+pkgname = kdeplasma-arch-update-notifier-git

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,20 @@
+# Maintainer: Bouteiller a2n Alan <a2n.dev@pm.me>
+
+pkgname=
+pkgver=1.0.0
+pkgrel=1
+pkgdesc=""
+arch=('any')
+url="https://github.com/bouteillerAlan/dracut-numlock"
+license=('MIT')
+source=("https://github.com/bouteillerAlan/${pkgname}/releases/download/${pkgname}-v${pkgver}/${pkgname}-v${pkgver}.tar.gz")
+depends=("sh")
+sha256sums=('74e9b5e4d58acff8835c4fd4503618afc035f5b29b02794be2463f8018eed39f')
+
+package() {
+  cd "${pkgname}-v${pkgver}"
+  install -Dm 644 50numlock/module-setup.sh "${pkgdir}"/usr/lib/dracut/modules.d/50numlock/module-setup.sh
+  install -Dm 644 50numlock/numlock.sh "${pkgdir}"/usr/lib/dracut/modules.d/50numlock/numlock.sh
+  install -D LICENSE "${pkgdir}"/usr/share/licenses/"${pkgname}"/LICENSE
+}
+

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,15 +1,25 @@
 # Maintainer: Bouteiller a2n Alan <a2n.dev@pm.me>
 
+# git rev-parse tagName
+_tag=7529bc6e829cc9ea7cc6e60f0b1662c430a74e06
+
 pkgname=
 pkgver=1.0.0
 pkgrel=1
 pkgdesc=""
 arch=('any')
-url="https://github.com/bouteillerAlan/dracut-numlock"
+url="https://github.com/bouteillerAlan/archupdate"
 license=('MIT')
-source=("https://github.com/bouteillerAlan/${pkgname}/releases/download/${pkgname}-v${pkgver}/${pkgname}-v${pkgver}.tar.gz")
-depends=("sh")
-sha256sums=('74e9b5e4d58acff8835c4fd4503618afc035f5b29b02794be2463f8018eed39f')
+source=("git+${url}/tree/${_tag}")
+depends=("konsole: for launching the update command"
+         "pacman-contrib: for checking updates on the main arch repository"
+         "yay: for checking updates on another arch repositories and doing the update")
+optdepends=("paru: if you want to replace yay with paru")
+
+pkgver() {
+  cd "${pkgname}"
+  git describe --tags
+}
 
 package() {
   cd "${pkgname}-v${pkgver}"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -29,8 +29,6 @@ pkgver() {
 package() {
   cd "${_souceName}"
   install -Dm 644 LICENSE -t "${pkgdir}"/usr/share/licenses/"${pkgname}"/
-
-  ## todo - make this stuff working and the dev is done
-  install -vDm 644 "${_plasmoidName}" -t "${pkgdir}"/usr/share/plasma/plasmoids/
+  find "${_plasmoidName}" -type f -exec install -Dm 644 "{}" "${pkgdir}/usr/share/plasma/plasmoids/{}" \;
 }
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,11 +10,12 @@ pkgname="kdeplasma-arch-update-notifier-git"
 pkgver=4.2.1
 pkgrel=1
 pkgdesc="KDE plasmoid that lets you know when arch updates are required. Takes all repo's into account (core, extra, aur, ...)."
-arch=(x86_64)
+arch=('any')
 url="https://github.com/bouteillerAlan/archupdate"
-license=("GPL-3.0")
+license=("GPL3")
 source=("git+${url}.git#tag=${_tag}?signed")
 depends=("konsole" "pacman-contrib" "yay" "kdialog")
+makedepends=("git")
 optdepends=("paru: paru support")
 sha256sums=("SKIP")
 validpgpkeys=(

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,30 +1,36 @@
 # Maintainer: Bouteiller a2n Alan <a2n.dev@pm.me>
 
 # git rev-parse tagName
-_tag=7529bc6e829cc9ea7cc6e60f0b1662c430a74e06
+_tag=ddaf9d2d3e0b75c4ba3c39d1060cbc30190990b7
+_plasmoidName="a2n.archupdate.plasmoid"
+_souceName="archupdate"
 
-pkgname=
-pkgver=1.0.0
+pkgname="kdeplasma-arch-update-notifier-git"
+# pkgver is updated automatically by the pkgver step
+pkgver=4.2.1
 pkgrel=1
-pkgdesc=""
-arch=('any')
+pkgdesc="KDE plasmoid that lets you know when arch updates are required. Takes all repo's into account (core, extra, aur, ...)."
+arch=(x86_64)
 url="https://github.com/bouteillerAlan/archupdate"
-license=('MIT')
-source=("git+${url}/tree/${_tag}")
-depends=("konsole: for launching the update command"
-         "pacman-contrib: for checking updates on the main arch repository"
-         "yay: for checking updates on another arch repositories and doing the update")
-optdepends=("paru: if you want to replace yay with paru")
+license=("GPL-3.0")
+source=("git+${url}.git#tag=${_tag}?signed")
+depends=("konsole" "pacman-contrib" "yay" "kdialog")
+optdepends=("paru: paru support")
+sha256sums=("SKIP")
+validpgpkeys=(
+  6A2ECC8A396F8A943A109A1E0F11C2A6BF79111E # Bouteiller a2n Alan <a2n.dev@pm.me>, retrieved from https://github.com/bouteillerAlan.gpg
+)
 
 pkgver() {
-  cd "${pkgname}"
-  git describe --tags
+  cd "${_souceName}"
+  git describe --tags | sed 's/^v//'
 }
 
 package() {
-  cd "${pkgname}-v${pkgver}"
-  install -Dm 644 50numlock/module-setup.sh "${pkgdir}"/usr/lib/dracut/modules.d/50numlock/module-setup.sh
-  install -Dm 644 50numlock/numlock.sh "${pkgdir}"/usr/lib/dracut/modules.d/50numlock/numlock.sh
-  install -D LICENSE "${pkgdir}"/usr/share/licenses/"${pkgname}"/LICENSE
+  cd "${_souceName}"
+  install -Dm 644 LICENSE -t "${pkgdir}"/usr/share/licenses/"${pkgname}"/
+
+  ## todo - make this stuff working and the dev is done
+  install -vDm 644 "${_plasmoidName}" -t "${pkgdir}"/usr/share/plasma/plasmoids/
 }
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,7 +10,7 @@ pkgname="kdeplasma-arch-update-notifier-git"
 pkgver=4.2.1
 pkgrel=1
 pkgdesc="KDE plasmoid that lets you know when arch updates are required. Takes all repo's into account (core, extra, aur, ...)."
-arch=('any')
+arch=("any")
 url="https://github.com/bouteillerAlan/archupdate"
 license=("GPL3")
 source=("git+${url}.git#tag=${_tag}?signed")


### PR DESCRIPTION
Create `PKGBUILD` file for deploying into the AUR

Todo : 
- [x] update the last command with `find` https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=plasma5-applets-latte-separator#n20
- [x] do the QA
- [x] create the `.SRCINFO` file (mind the weird stuff about the last commit https://medium.com/@a2nb/submitting-a-package-to-the-aur-e9117d07494d#b3b0)