### PR TITLE
Feat/extra dot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.tar.gz
 .kdev4/*
 archupdate.kdev4
+.idea/*

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+### v6.3.0
+  - Add a new parameter for splitting the dot between two CMD
+  - The dots are customizable in color and position
+
 ### v6.2.0
   - Add parameters for the last two cmds without parameters (those of the update :))
   - Added a kdialog trigger if a list or count cmd has an error

--- a/README.md
+++ b/README.md
@@ -66,30 +66,32 @@ Go to the 'System Tray Settings' menu and activate it :)
 
 ![screenshot of the settings of the plugin](git-assets/img/set1.png)
 
-| Name | Description | Result |
-|--|--|--|
-| Command & Debug | | |
-| Interval configuration | set the interval between each execution of the update check function | the `updater` is launch each X minutes |
-| Debug | Enable the debug mode if set to true | Show each command launch by the plasmoid with `ARCHUPDATE` at the beggining (for regex search) |
-| Retry | Enable the retry mode if set to true | Retry the Count or the List cmd if `stderr` is not empty |
-| Do not close the terminal at the end | if true add the `--noclose` flag into the `konsole` command | Prevent the console to close at the end of the update command |
-| Count ARCH command | The command you want to execute for counting the packages for CORE and EXTRA (default: `checkupdates [pipe] wc -l`) | The `updater` exec this command |
-| Count AUR command | The command you want to execute for counting the packages for the other db (default: `yay -Qua [pipe] wc -l`) | The `updater` exec this command |
-| Update all command | The command for updating all the package at once | Pass the command to the Terminal cmd (or the cmd with no close) |
-| Update one command | The command for updating one package via the popup | Pass the command to the Terminal cmd (or the cmd with no close) and add the package name at the end |
-| Terminal cmd | The command for launching the update all or one cmd | Launch the update cmd and automatically close at the end of it |
-| Terminal cmd & no close | The command for launching the update all or one cmd, executed only when "Do not close at the end" is checked | Launch the update cmd and rest open at the end of it |
-| Display | | |
-| Show a dot in place of the label | Replace the label with a colored dot | If the total count is > than 0 the dot is visible, otherwise nothing is shown (no label, no dot) |
-| Custom dot color | If you want to customize the color of the dot | If not checked the dot get the color from your theme via `PlasmaCore.Theme.textColor` |
-| Separate result | If you want to have the total for *arch* and the total for the other db in the label | Set the label text to `' ' + totalArch + separator + totalAur + ' '` |
-| Separator | The text you want to have for, space available | Inject the text you put into the label |
-| Popup | | |
-| Custom X color | You can tick the box if you want a custom color on the X element | Change the color on the popup element and on the preview in the same page |
-| Separator text | Custom text for the version separator | Use the text provided to separate versions in the text |
-| Mouse action | | |
-| Click configuration | Choose the type of action you want to do for each click on the mouse | Left click to check, middle click to update OR Middle click to check, left click to update |
-| Main action behavior | If you want to refresh the list or open the popup when you click | Main click depend on the choice made in the Click configuration settings |
+| Name                                 | Description                                                                                                         | Result                                                                                              |
+|--------------------------------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+| Command & Debug                      |                                                                                                                     |                                                                                                     |
+| Interval configuration               | set the interval between each execution of the update check function                                                | the `updater` is launch each X minutes                                                              |
+| Debug                                | Enable the debug mode if set to true                                                                                | Show each command launch by the plasmoid with `ARCHUPDATE` at the beggining (for regex search)      |
+| Retry                                | Enable the retry mode if set to true                                                                                | Retry the Count or the List cmd if `stderr` is not empty                                            |
+| Do not close the terminal at the end | if true add the `--noclose` flag into the `konsole` command                                                         | Prevent the console to close at the end of the update command                                       |
+| Count ARCH command                   | The command you want to execute for counting the packages for CORE and EXTRA (default: `checkupdates [pipe] wc -l`) | The `updater` exec this command                                                                     |
+| Count AUR command                    | The command you want to execute for counting the packages for the other db (default: `yay -Qua [pipe] wc -l`)       | The `updater` exec this command                                                                     |
+| Update all command                   | The command for updating all the package at once                                                                    | Pass the command to the Terminal cmd (or the cmd with no close)                                     |
+| Update one command                   | The command for updating one package via the popup                                                                  | Pass the command to the Terminal cmd (or the cmd with no close) and add the package name at the end |
+| Terminal cmd                         | The command for launching the update all or one cmd                                                                 | Launch the update cmd and automatically close at the end of it                                      |
+| Terminal cmd & no close              | The command for launching the update all or one cmd, executed only when "Do not close at the end" is checked        | Launch the update cmd and rest open at the end of it                                                |
+| Display                              |                                                                                                                     |                                                                                                     |
+| Show a dot in place of the label     | Replace the label with a colored dot                                                                                | If the total count is > than 0 the dot is visible, otherwise nothing is shown (no label, no dot)    |
+| Custom dot color                     | If you want to customize the color of the dot                                                                       | If not checked the dot get the color from your theme via `PlasmaCore.Theme.textColor`               |
+| Custom dot position                  | If you want to customize the position of the dot                                                                    | By default to Top Right                                                                             |
+| Separate dot                         | If you want to have the total for *arch* and the total for the other db via two dot                                 | Set two dot one for `totalArch` and one for `totalAur`                                              |
+| Separate result                      | If you want to have the total for *arch* and the total for the other db in the label                                | Set the label text to `' ' + totalArch + separator + totalAur + ' '`                                |
+| Separator                            | The text you want to have for, space available                                                                      | Inject the text you put into the label                                                              |
+| Popup                                |                                                                                                                     |                                                                                                     |
+| Custom X color                       | You can tick the box if you want a custom color on the X element                                                    | Change the color on the popup element and on the preview in the same page                           |
+| Separator text                       | Custom text for the version separator                                                                               | Use the text provided to separate versions in the text                                              |
+| Mouse action                         |                                                                                                                     |                                                                                                     |
+| Click configuration                  | Choose the type of action you want to do for each click on the mouse                                                | Left click to check, middle click to update OR Middle click to check, left click to update          |
+| Main action behavior                 | If you want to refresh the list or open the popup when you click                                                    | Main click depend on the choice made in the Click configuration settings                            |
 
 ### Regarding the customization of the commands
 

--- a/a2n.archupdate.plasmoid/contents/config/main.xml
+++ b/a2n.archupdate.plasmoid/contents/config/main.xml
@@ -87,23 +87,59 @@ http://www.kde.org/standards/kcfg/1.0/kcfg.xsd" >
 
 <group name="displayConfigPage">
     <entry name="separateResult" type="Bool">
-    <default>false</default>
+        <default>false</default>
+    </entry>
+
+    <entry name="separateDot" type="Bool">
+        <default>false</default>
     </entry>
 
     <entry name="separator" type="String">
-    <default>~</default>
+        <default>~</default>
     </entry>
 
-    <entry name="dot" type="Bool">
-    <default>false</default>
+    <entry name="mainDot" type="Bool">
+        <default>false</default>
     </entry>
 
-    <entry name="dotColor" type="String">
-    <default>white</default>
+    <entry name="mainDotPosition" type="Enum">
+        <choices>
+            <choice name="Top Right" />
+            <choice name="Top Left" />
+            <choice name="Bottom Right" />
+            <choice name="Bottom Left" />
+        </choices>
+        <default>2</default>
     </entry>
 
-    <entry name="dotUseCustomColor" type="Bool">
-    <default>false</default>
+    <entry name="secondDot" type="Bool">
+        <default>false</default>
+    </entry>
+
+    <entry name="secondDotPosition" type="Enum">
+        <choices>
+            <choice name="Top Right" />
+            <choice name="Top Left" />
+            <choice name="Bottom Right" />
+            <choice name="Bottom Left" />
+        </choices>
+        <default>3</default>
+    </entry>
+
+    <entry name="mainDotColor" type="String">
+        <default>white</default>
+    </entry>
+
+    <entry name="secondDotColor" type="String">
+        <default>white</default>
+    </entry>
+
+    <entry name="mainDotUseCustomColor" type="Bool">
+        <default>false</default>
+    </entry>
+
+    <entry name="secondDotUseCustomColor" type="Bool">
+        <default>false</default>
     </entry>
 
     <entry name="iconColor" type="String">

--- a/a2n.archupdate.plasmoid/contents/config/main.xml
+++ b/a2n.archupdate.plasmoid/contents/config/main.xml
@@ -90,10 +90,6 @@ http://www.kde.org/standards/kcfg/1.0/kcfg.xsd" >
         <default>false</default>
     </entry>
 
-    <entry name="separateDot" type="Bool">
-        <default>false</default>
-    </entry>
-
     <entry name="separator" type="String">
         <default>~</default>
     </entry>

--- a/a2n.archupdate.plasmoid/contents/ui/Compact.qml
+++ b/a2n.archupdate.plasmoid/contents/ui/Compact.qml
@@ -17,9 +17,18 @@ Item {
 
   property bool separateResult: plasmoid.configuration.separateResult
   property string separator: plasmoid.configuration.separator
-  property bool dot: plasmoid.configuration.dot
-  property bool dotUseCustomColor: plasmoid.configuration.dotUseCustomColor
-  property string dotColor: plasmoid.configuration.dotColor
+
+  property bool separateDot: plasmoid.configuration.separateDot
+
+  property bool mainDot: plasmoid.configuration.mainDot
+  property bool mainDotUseCustomColor: plasmoid.configuration.mainDotUseCustomColor
+  property string mainDotColor: plasmoid.configuration.mainDotColor
+  property int mainDotPosition: parseInt(plasmoid.configuration.mainDotPosition, 10)
+
+  property bool secondDot: plasmoid.configuration.secondDot
+  property bool secondDotUseCustomColor: plasmoid.configuration.secondDotUseCustomColor
+  property string secondDotColor: plasmoid.configuration.secondDotColor
+  property int secondDotPosition: parseInt(plasmoid.configuration.secondDotPosition, 10)
 
   property bool onUpdate: false
   property bool onRefresh: false
@@ -72,6 +81,16 @@ Item {
     return (parseInt(totalArch, 10) + parseInt(totalAur, 10)) > 0
   }
 
+  // return true if update is needed (total > 0)
+  function isArchUpdateNeeded() {
+    return (parseInt(totalArch, 10) > 0)
+  }
+
+  // return true if update is needed (total > 0)
+  function isAurUpdateNeeded() {
+    return (parseInt(totalAur, 10) > 0)
+  }
+
   // map the cmd signal
   Connections {
     target: cmd
@@ -104,13 +123,26 @@ Item {
     }
 
     Rectangle {
-      visible: dot && isUpdateNeeded()
+      id: mainDotRect
+      visible: separateDot ? mainDot && isArchUpdateNeeded() : mainDot && isUpdateNeeded()
       height: container.height / 2.5
       width: height
       radius: height / 2
-      color: dotUseCustomColor ? dotColor : PlasmaCore.Theme.textColor
+      color: mainDotUseCustomColor ? mainDotColor : PlasmaCore.Theme.textColor
       anchors {
         right: container.right
+        bottom: container.bottom
+      }
+    }
+
+    Rectangle {
+      visible: (separateDot) && (mainDot) && (secondDot && isAurUpdateNeeded())
+      height: container.height / 2.5
+      width: height
+      radius: height / 2
+      color: secondDotUseCustomColor ? secondDotColor : PlasmaCore.Theme.textColor
+      anchors {
+        left: container.left
         bottom: container.bottom
       }
     }
@@ -121,7 +153,7 @@ Item {
         right: container.right
       }
       text: generateResult()
-      visible: !isPanelVertical && !dot
+      visible: !isPanelVertical && !mainDot
       icon: updateIcon
     }
 
@@ -131,7 +163,7 @@ Item {
         right: container.right
       }
       text: generateResult()
-      visible: isPanelVertical && !dot
+      visible: isPanelVertical && !mainDot
       icon: updateIcon
     }
 
@@ -152,6 +184,10 @@ Item {
           if (mouse.button == Qt.MiddleButton) onMClick()
         }
       }
+    }
+
+    Component.onCompleted: {
+      console.log("xxxxxxxxxxxxxxxxx")
     }
   }
 }

--- a/a2n.archupdate.plasmoid/contents/ui/Compact.qml
+++ b/a2n.archupdate.plasmoid/contents/ui/Compact.qml
@@ -18,8 +18,6 @@ Item {
   property bool separateResult: plasmoid.configuration.separateResult
   property string separator: plasmoid.configuration.separator
 
-  property bool separateDot: plasmoid.configuration.separateDot
-
   property bool mainDot: plasmoid.configuration.mainDot
   property bool mainDotUseCustomColor: plasmoid.configuration.mainDotUseCustomColor
   property string mainDotColor: plasmoid.configuration.mainDotColor
@@ -122,9 +120,9 @@ Item {
       source: iconUpdate
     }
 
+    // MAIN BR
     Rectangle {
-      id: mainDotRect
-      visible: separateDot ? mainDot && isArchUpdateNeeded() : mainDot && isUpdateNeeded()
+      visible: (secondDot ? mainDot && isArchUpdateNeeded() : mainDot && isUpdateNeeded()) && mainDotPosition === 2
       height: container.height / 2.5
       width: height
       radius: height / 2
@@ -135,8 +133,61 @@ Item {
       }
     }
 
+    // MAIN BL
     Rectangle {
-      visible: (separateDot) && (mainDot) && (secondDot && isAurUpdateNeeded())
+      visible: (secondDot ? mainDot && isArchUpdateNeeded() : mainDot && isUpdateNeeded()) && mainDotPosition === 3
+      height: container.height / 2.5
+      width: height
+      radius: height / 2
+      color: mainDotUseCustomColor ? mainDotColor : PlasmaCore.Theme.textColor
+      anchors {
+        left: container.left
+        bottom: container.bottom
+      }
+    }
+
+    // MAIN TR
+    Rectangle {
+      visible: (secondDot ? mainDot && isArchUpdateNeeded() : mainDot && isUpdateNeeded()) && mainDotPosition === 0
+      height: container.height / 2.5
+      width: height
+      radius: height / 2
+      color: mainDotUseCustomColor ? mainDotColor : PlasmaCore.Theme.textColor
+      anchors {
+        right: container.right
+        top: container.top
+      }
+    }
+
+    // MAIN TL
+    Rectangle {
+      visible: (secondDot ? mainDot && isArchUpdateNeeded() : mainDot && isUpdateNeeded()) && mainDotPosition === 1
+      height: container.height / 2.5
+      width: height
+      radius: height / 2
+      color: mainDotUseCustomColor ? mainDotColor : PlasmaCore.Theme.textColor
+      anchors {
+        left: container.left
+        top: container.top
+      }
+    }
+
+    // SECOND BR
+    Rectangle {
+      visible: (secondDot && mainDot && isAurUpdateNeeded()) && secondDotPosition === 2
+      height: container.height / 2.5
+      width: height
+      radius: height / 2
+      color: secondDotUseCustomColor ? secondDotColor : PlasmaCore.Theme.textColor
+      anchors {
+        right: container.right
+        bottom: container.bottom
+      }
+    }
+
+    // SECOND BL
+    Rectangle {
+      visible: (secondDot && mainDot && isAurUpdateNeeded()) && secondDotPosition === 3
       height: container.height / 2.5
       width: height
       radius: height / 2
@@ -145,6 +196,32 @@ Item {
         left: container.left
         bottom: container.bottom
       }
+    }
+
+    // SECOND TR
+    Rectangle {
+      visible: (secondDot && mainDot && isAurUpdateNeeded()) && secondDotPosition === 0
+      height: container.height / 2.5
+      width: height
+      radius: height / 2
+      color: secondDotUseCustomColor ? secondDotColor : PlasmaCore.Theme.textColor
+      anchors {
+        right: container.right
+        top: container.top
+      }
+    }
+
+    // SECOND TL
+    Rectangle {
+      visible: (secondDot && mainDot && isAurUpdateNeeded()) && secondDotPosition === 1
+      height: container.height / 2.5
+      width: height
+      radius: height / 2
+      color: secondDotUseCustomColor ? secondDotColor : PlasmaCore.Theme.textColor
+      anchors {
+        left: container.left
+        top: container.top
+     }
     }
 
     WorkspaceComponents.BadgeOverlay { // for the horizontal bar
@@ -184,10 +261,6 @@ Item {
           if (mouse.button == Qt.MiddleButton) onMClick()
         }
       }
-    }
-
-    Component.onCompleted: {
-      console.log("xxxxxxxxxxxxxxxxx")
     }
   }
 }

--- a/a2n.archupdate.plasmoid/contents/ui/config/configCommand.qml
+++ b/a2n.archupdate.plasmoid/contents/ui/config/configCommand.qml
@@ -43,22 +43,6 @@ Kirigami.ScrollablePage {
 
     Kirigami.InlineMessage {
       Layout.fillWidth: true
-      text: "You must have the <a href=\"https://archlinux.org/packages/extra/x86_64/konsole/\">konsole</a> package installed for this widget to work."
-      onLinkActivated: Qt.openUrlExternally(link)
-      type: Kirigami.MessageType.Warning
-      visible: !plasmoid.configuration.konsoleIsValid
-    }
-
-    Kirigami.InlineMessage {
-      Layout.fillWidth: true
-      text: "You must have the <a href=\"https://archlinux.org/packages/extra/x86_64/pacman-contrib/\">pacman-contrib</a> package installed for this widget to work."
-      onLinkActivated: Qt.openUrlExternally(link)
-      type: Kirigami.MessageType.Warning
-      visible: !plasmoid.configuration.checkupdateIsValid
-    }
-
-    Kirigami.InlineMessage {
-      Layout.fillWidth: true
       text: "This option enable log for each cmd exec by the plugin. (regex: ARCHUPDATE)"
       visible: debugModeBox.checked
     }

--- a/a2n.archupdate.plasmoid/contents/ui/config/configDisplay.qml
+++ b/a2n.archupdate.plasmoid/contents/ui/config/configDisplay.qml
@@ -11,9 +11,17 @@ Kirigami.ScrollablePage {
     property alias cfg_separateResult: separateResult.checked
     property alias cfg_separator: separator.text
 
-    property alias cfg_dot: dot.checked
-    property alias cfg_dotColor: dotColor.color
-    property alias cfg_dotUseCustomColor: dotUseCustomColor.checked
+    property alias cfg_separateDot: separateDot.checked
+    property alias cfg_mainDotPosition: mainDotPosition.currentIndex
+    property alias cfg_secondDotPosition: secondDotPosition.currentIndex
+
+    property alias cfg_mainDot: mainDot.checked
+    property alias cfg_mainDotColor: mainDotColor.color
+    property alias cfg_mainDotUseCustomColor: mainDotUseCustomColor.checked
+
+    property alias cfg_secondDot: secondDot.checked
+    property alias cfg_secondDotColor: secondDotColor.color
+    property alias cfg_secondDotUseCustomColor: secondDotUseCustomColor.checked
 
     property alias cfg_iconColor: iconColor.color
     property alias cfg_iconUseCustomColor: iconUseCustomColor.checked
@@ -69,25 +77,70 @@ Kirigami.ScrollablePage {
 
         Kirigami.FormLayout {
             Controls.CheckBox {
-                id: dot
+                id: mainDot
                 Kirigami.FormData.label: "Show a dot in place of the label: "
                 checked: false
             }
 
             RowLayout {
-                Kirigami.FormData.label: "Custom dot color: "
-                visible: dot.checked
+                Kirigami.FormData.label: "Custom main dot color: "
+                visible: mainDot.checked
                 Controls.CheckBox {
-                    id: dotUseCustomColor
+                    id: mainDotUseCustomColor
                     checked: false
                 }
 
                 KQuickControls.ColorButton {
-                    id: dotColor
-                    enabled: dotUseCustomColor.checked
+                    id: mainDotColor
+                    enabled: mainDotUseCustomColor.checked
+                }
+
+                Controls.ComboBox {
+                    id: mainDotPosition
+                    enabled: mainDot.checked
+                    model: ["Top Right", "Top Left", "Bottom Right", "Bottom Left"]
+                    onActivated: cfg_mainDotPosition = index
                 }
             }
+        }
 
+        Kirigami.FormLayout {
+            visible: mainDot.checked
+            Controls.CheckBox {
+                id: separateDot
+                Kirigami.FormData.label: "Separate the dot between the two command: "
+                checked: false
+            }
+        }
+
+        Kirigami.FormLayout {
+            visible: separateDot.checked && mainDot.checked
+            Controls.CheckBox {
+                id: secondDot
+                Kirigami.FormData.label: "Show a dot for AUR update: "
+                checked: false && separateDot.checked
+            }
+
+            RowLayout {
+                Kirigami.FormData.label: "Custom AUR dot color: "
+                visible: secondDot.checked
+                Controls.CheckBox {
+                    id: secondDotUseCustomColor
+                    checked: false
+                }
+
+                KQuickControls.ColorButton {
+                    id: secondDotColor
+                    enabled: secondDotUseCustomColor.checked
+                }
+
+                Controls.ComboBox {
+                    id: secondDotPosition
+                    enabled: secondDot.checked
+                    model: ["Top Right", "Top Left", "Bottom Right", "Bottom Left"]
+                    onActivated: cfg_secondDotPosition = currentIndex
+                }
+            }
         }
 
         Kirigami.FormLayout {
@@ -117,7 +170,6 @@ Kirigami.ScrollablePage {
                 Kirigami.FormData.label: "Separator: "
                 visible: separateResult.checked
             }
-
         }
 
 

--- a/a2n.archupdate.plasmoid/contents/ui/config/configDisplay.qml
+++ b/a2n.archupdate.plasmoid/contents/ui/config/configDisplay.qml
@@ -11,17 +11,15 @@ Kirigami.ScrollablePage {
     property alias cfg_separateResult: separateResult.checked
     property alias cfg_separator: separator.text
 
-    property alias cfg_separateDot: separateDot.checked
-    property alias cfg_mainDotPosition: mainDotPosition.currentIndex
-    property alias cfg_secondDotPosition: secondDotPosition.currentIndex
-
     property alias cfg_mainDot: mainDot.checked
     property alias cfg_mainDotColor: mainDotColor.color
     property alias cfg_mainDotUseCustomColor: mainDotUseCustomColor.checked
+    property alias cfg_mainDotPosition: mainDotPosition.currentIndex
 
     property alias cfg_secondDot: secondDot.checked
     property alias cfg_secondDotColor: secondDotColor.color
     property alias cfg_secondDotUseCustomColor: secondDotUseCustomColor.checked
+    property alias cfg_secondDotPosition: secondDotPosition.currentIndex
 
     property alias cfg_iconColor: iconColor.color
     property alias cfg_iconUseCustomColor: iconUseCustomColor.checked
@@ -83,7 +81,7 @@ Kirigami.ScrollablePage {
             }
 
             RowLayout {
-                Kirigami.FormData.label: "Custom main dot color: "
+                Kirigami.FormData.label: "Custom main dot options: "
                 visible: mainDot.checked
                 Controls.CheckBox {
                     id: mainDotUseCustomColor
@@ -107,7 +105,7 @@ Kirigami.ScrollablePage {
         Kirigami.FormLayout {
             visible: mainDot.checked
             Controls.CheckBox {
-                id: separateDot
+                id: secondDot
                 Kirigami.FormData.label: "Separate the dot between the two command: "
                 checked: false
             }
@@ -115,14 +113,9 @@ Kirigami.ScrollablePage {
 
         Kirigami.FormLayout {
             visible: separateDot.checked && mainDot.checked
-            Controls.CheckBox {
-                id: secondDot
-                Kirigami.FormData.label: "Show a dot for AUR update: "
-                checked: false && separateDot.checked
-            }
 
             RowLayout {
-                Kirigami.FormData.label: "Custom AUR dot color: "
+                Kirigami.FormData.label: "Custom second dot options: "
                 visible: secondDot.checked
                 Controls.CheckBox {
                     id: secondDotUseCustomColor

--- a/a2n.archupdate.plasmoid/metadata.json
+++ b/a2n.archupdate.plasmoid/metadata.json
@@ -12,7 +12,7 @@
         "Id": "a2n.archupdate.plasmoid",
         "License": "GPL-3.0+",
         "Name": "Arch Update Counter",
-        "Version": "6.2.0",
+        "Version": "6.3.0",
         "Website": "https://github.com/bouteillerAlan/archupdate",
         "Depends": ["konsole", "pacman-contrib", "yay"],
         "EnabledByDefault": false


### PR DESCRIPTION
Add a second dot if the user wants to separate the AUR count to the ARCH count but want to keep the dot signal.

Todo : 

- [x] separate the dot
- [x] add a dropdown for the position for each dot
- [x] ~remap the `anchors` with `state` ([see doc here](https://doc.qt.io/qt-5/qml-qtquick-anchorchanges.html))~ changed with a working but messy code :shrug: 
- [x] signed tag to `6.3.0`
- [ ] create github release
- [ ] edit aur repo
- [ ] deploy on aur
- [ ] deploy on store and update store metadata